### PR TITLE
update to 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM openjdk:8-alpine
+FROM ripencc/rpki-validator-3-docker:alpine
 RUN apk add --no-cache bash
-RUN apk add --no-cache rsync
-ADD rpki-validator-3.0-312-dist.tar.gz /usr/src/rpki-valid
-ADD application.properties /usr/src/rpki-valid/rpki-validator-3.0-312/conf
-ADD rpki-validator-3.sh /usr/src/rpki-valid/rpki-validator-3.0-312/
-ADD arin-ote.tal /usr/src/rpki-valid/rpki-validator-3.0-312/
-RUN chmod 755 /usr/src/rpki-valid/rpki-validator-3.0-312/rpki-validator-3.sh
-WORKDIR /usr/src/rpki-valid/rpki-validator-3.0-312
+
+WORKDIR /var/lib/rpki-validator-3
+ADD application.properties /var/lib/rpki-validator-3/conf/
+ADD rpki-validator-3.sh /var/lib/rpki-validator-3/
+ADD arin-ote.tal /var/lib/rpki-validator-3/
+
+RUN chmod 755 /var/lib/rpki-validator-3/rpki-validator-3.sh
+
 ENTRYPOINT ["./rpki-validator-3.sh"]
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Both containers set to listen on localhost only by default. RPKI Validator can b
 
 ```docker run -d -e listen_any=true -p 8080:8080 toomscj7/rpki3-validator-alpine```
 
-The ARIN TAL is not installed by default.  This can be set to be pulled at run time with the get_arin_tal=true env variable.  Official site located here: https://www.arin.net/resources/rpki/tal.html.  You will need to read the conditions of their relying party agreement.  
+The ARIN TAL is not installed by default.  This can be set to be pulled at run time with the `get_arin_tal=true` env variable.  
+
+Attention: This package requires the download of the ARIN TAL and agreement to the [ARIN Relying Party Agreement (RPA)](https://www.arin.net/resources/manage/rpki/rpa.pdf).
+
+By using `get_arin_tal=true`, you are agreeing to the ARIN RPA.  
 
 ```docker run -d -e listen_any=true -e get_arin_tal=true -p 8080:8080 toomscj7/rpki3-validator-alpine```
 

--- a/application.properties
+++ b/application.properties
@@ -38,6 +38,9 @@
 # https://github.com/RIPE-NCC/rpki-validator-3/wiki/Run-the-RPKI-Validator-behind-an-apache-proxy
 server.port=8080
 
+# For user agent when fetching RRDP
+validator.version=3.1-2019.10.29_16.55.05
+
 ################
 # Use the following settings to change JVM parameters
 #
@@ -49,15 +52,14 @@ server.port=8080
 # - You may want to raise this value if you see 'out of memory' errors in the log
 # - A higher maximum will allow the JVM to use more system memory and spend less time on
 #   garbage collection (slight speed improvements possible)
-jvm.memory.initial=1024m       # -Xms jvm option -> initial memory claimed by the jvm
-jvm.memory.maximum=1024m       # -Xmx jvm option -> maximum memory for the jvm
+jvm.memory.initial=512m       # -Xms jvm option -> initial memory claimed by the jvm
+jvm.memory.maximum=1536m      # -Xmx jvm option -> maximum memory for the jvm
 
 #
 # The following directive is used to set where the rpki-validator keeps its
-# database.
+# database and the SLURM file
 #
-# Note that the database cannot be shared by multiple instances
-spring.datasource.url=jdbc:h2:file:./db/rpki-validator.h2
+rpki.validator.data.path=.
 
 #
 # The following directive is used to set where preconfigured TALs that ship with
@@ -74,14 +76,10 @@ rpki.validator.rsync.local.storage.directory=./rsync
 ########################
 # There should be no need to modify any of the following directives
 
-spring.datasource.name=rpki
-spring.datasource.username=rpki
-spring.datasource.password=rpki
-
 #
 # Use the following directives if you want to increase (INFO, DEBUG) or decrease (ERROR)
 # the level of messages logged.
-logging.level.net.ripe.rpki.validator3=WARN
+logging.level.net.ripe.rpki.validator3=INFO
 logging.level.org.springframework.context.annotation=WARN
 logging.level.org.quartz=OFF
 
@@ -93,12 +91,27 @@ rpki.validator.rsync.repository.download.interval=PT10M
 
 rpki.validator.rrdp.trust.all.tls.certificates=true
 
-rpki.validator.rpki.object.cleanup.interval.ms=3600000
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
 
-rpki.validator.validation.run.cleanup.interval.ms=3600000
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 
+# Proxy host to be used for RRDP/https requests
+#rpki.validator.http.proxy.host=
+
+# Proxy port to be used for RRDP/https requests
+#rpki.validator.http.proxy.port=
+
+# Change the initial and maximum memory for the JVM.
+# Normally the default settings should be sufficient.
+#
+# Notes:
+# - 1536 megabytes of memory is needed for the current size of the combined RPKI repositories
+#   and BGP tables
+# - You may want to raise this value if you see 'out of memory' errors in the log
+# - A higher maximum will allow the JVM to use more system memory and spend less time on
+#   garbage collection (slight speed improvements possible)
+# jvm.mem.initial=1024m       # -Xms jvm option -> initial memory claimed by the jvm
+# jvm.mem.maximum=1536m       # -Xmx jvm option -> maximum memory for the jvm
 
 # By default the validator will listen on localhost ONLY
 #


### PR DESCRIPTION
Updates to 3.1 and uses the ripencc/rpki-validator-3-docker:alpine docker image.

Modified the README to attempt to adhere to the ARIN RPA.